### PR TITLE
Add a `Program` entry point shim to the `RazorPlugin`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nuget.exe
 node_modules
 project.lock.json
 **/[Cc]ompiler/[Rr]esources/**/*.js
+launchSettings.json

--- a/src/Microsoft.AspNet.Tooling.Razor/Program.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/Program.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.Dnx.Runtime;
+using Microsoft.Dnx.Runtime.Common.CommandLine;
+
+namespace Microsoft.AspNet.Tooling.Razor
+{
+    public class Program
+    {
+        private readonly IAssemblyLoadContext _assemblyLoadContext;
+
+        public Program(IAssemblyLoadContextAccessor assemblyLoadContextAccessor)
+        {
+            _assemblyLoadContext = assemblyLoadContextAccessor.Default;
+        }
+
+        public int Main(string[] args)
+        {
+            try
+            {
+                var app = new CommandLineApplication
+                {
+                    Name = "razor-tooling",
+                    FullName = "Microsoft Razor Tooling Utility",
+                    Description = "Resolves Razor tooling specific information.",
+                    ShortVersionGetter = GetInformationalVersion,
+                };
+                app.HelpOption("-?|-h|--help");
+
+                ResolveProtocolCommand.Register(app);
+                ResolveTagHelpersCommand.Register(app, _assemblyLoadContext);
+
+                app.OnExecute(() =>
+                {
+                    app.ShowHelp();
+                    return 2;
+                });
+
+                return app.Execute(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {Environment.NewLine}{ex.Message}.");
+                return 1;
+            }
+        }
+
+        private static string GetInformationalVersion()
+        {
+            var assembly = typeof(Program).GetTypeInfo().Assembly;
+            var attributes = assembly.GetCustomAttributes(
+                typeof(AssemblyInformationalVersionAttribute)) as AssemblyInformationalVersionAttribute[];
+
+            var versionAttribute = attributes.Length == 0 ?
+                assembly.GetName().Version.ToString() :
+                attributes[0].InformationalVersion;
+
+            return versionAttribute;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Tooling.Razor/ResolveProtocolCommand.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/ResolveProtocolCommand.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Dnx.Runtime.Common.CommandLine;
+
+namespace Microsoft.AspNet.Tooling.Razor
+{
+    internal static class ResolveProtocolCommand
+    {
+        public static void Register(CommandLineApplication app)
+        {
+            app.Command("resolve-protocol", config =>
+            {
+                config.Description = "Resolves protocol used to resolve TagHeleprDescriptors.";
+                config.HelpOption("-?|-h|--help");
+                var clientProtocol = config.Argument(
+                    "[clientProtocol]",
+                    "Client protocol used to consume returned TagHelperDescriptors.");
+
+                config.OnExecute(() =>
+                {
+                    var pluginProtocol = new RazorPlugin(messageBroker: null).Protocol;
+                    var resolvedProtocol = ResolveProtocol(clientProtocol.Value, pluginProtocol);
+
+                    Console.WriteLine(resolvedProtocol);
+
+                    return 0;
+                });
+            });
+        }
+
+        public static int ResolveProtocol(CommandOption clientProtocolCommand, int pluginProtocol)
+        {
+            int resolvedProtocol;
+            if (clientProtocolCommand.HasValue())
+            {
+                resolvedProtocol = ResolveProtocol(clientProtocolCommand.Value(), pluginProtocol);
+            }
+            else
+            {
+                // Client protocol wasn't provided, use the plugin's protocol.
+                resolvedProtocol = pluginProtocol;
+            }
+
+            return resolvedProtocol;
+        }
+
+        private static int ResolveProtocol(string clientProtocolString, int pluginProtocol)
+        {
+            var clientProtocol = int.Parse(clientProtocolString);
+
+            // Client and plugin protocols are max values; meaning support is <= value. The goal in this method is
+            // to return the maximum protocol supported by both parties (client and plugin).
+            var resolvedProtocol = Math.Min(clientProtocol, pluginProtocol);
+
+            return resolvedProtocol;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Tooling.Razor/ResolveTagHelpersCommand.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/ResolveTagHelpersCommand.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.Razor;
+using Microsoft.AspNet.Tooling.Razor.Models.IncomingMessages;
+using Microsoft.AspNet.Tooling.Razor.Models.OutgoingMessages;
+using Microsoft.Dnx.DesignTimeHost;
+using Microsoft.Dnx.Runtime;
+using Microsoft.Dnx.Runtime.Common.CommandLine;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNet.Tooling.Razor
+{
+    internal static class ResolveTagHelpersCommand
+    {
+        public static void Register(CommandLineApplication app, IAssemblyLoadContext assemblyLoadContext)
+        {
+            app.Command("resolve-taghelpers", config =>
+            {
+                config.Description = "Resolves TagHelperDescriptors in the specified assembly(s).";
+                config.HelpOption("-?|-h|--help");
+                var clientProtocol = config.Option(
+                    "-p|--protocol",
+                    "Provide client protocol version.",
+                    CommandOptionType.SingleValue);
+                var assemblyNames = config.Argument(
+                    "[name]",
+                    "Assembly name to resolve TagHelperDescriptors in.",
+                    multipleValues: true);
+
+                config.OnExecute(() =>
+                {
+                    var messageBroker = new CommandMessageBroker();
+                    var plugin = new RazorPlugin(messageBroker);
+                    var resolvedProtocol = ResolveProtocolCommand.ResolveProtocol(clientProtocol, plugin.Protocol);
+
+                    plugin.Protocol = resolvedProtocol;
+
+                    var success = true;
+                    foreach (var assemblyName in assemblyNames.Values)
+                    {
+                        var messageData = new ResolveTagHelperDescriptorsRequestData
+                        {
+                            AssemblyName = assemblyName,
+                            SourceLocation = SourceLocation.Zero
+                        };
+                        var message = new RazorPluginRequestMessage(
+                            RazorPluginMessageTypes.ResolveTagHelperDescriptors,
+                            JObject.FromObject(messageData));
+
+                        success &= plugin.ProcessMessage(JObject.FromObject(message), assemblyLoadContext);
+                    }
+
+                    var resolvedDescriptors = messageBroker.Results.SelectMany(result => result.Data.Descriptors);
+                    var serializedDescriptors = JsonConvert.SerializeObject(resolvedDescriptors, Formatting.Indented);
+
+                    Console.WriteLine(serializedDescriptors);
+
+                    return success ? 0 : 1;
+                });
+            });
+        }
+
+        private class CommandMessageBroker : IPluginMessageBroker
+        {
+            public CommandMessageBroker()
+            {
+                Results = new List<ResolveTagHelperDescriptorsMessage>();
+            }
+
+            public List<ResolveTagHelperDescriptorsMessage> Results { get; }
+
+            public void SendMessage(object data)
+            {
+                var responseMessage = data as ResolveTagHelperDescriptorsMessage;
+                if (responseMessage != null)
+                {
+                    Results.Add(responseMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Tooling.Razor/project.json
+++ b/src/Microsoft.AspNet.Tooling.Razor/project.json
@@ -1,20 +1,26 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.AspNet.Razor.Runtime": "4.0.0-*",
-        "Microsoft.Dnx.DesignTimeHost.Abstractions": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Dnx.Runtime.Abstractions": { "version": "1.0.0-*", "type": "build" },
-        "Newtonsoft.Json": "6.0.6"
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Razor.Runtime": "4.0.0-*",
+    "Microsoft.Dnx.DesignTimeHost.Abstractions": { "version": "1.0.0-*", "type": "build" },
+    "Microsoft.Dnx.Runtime.Abstractions": { "version": "1.0.0-*", "type": "build" },
+    "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
+    "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-*",
+    "Newtonsoft.Json": "6.0.6"
+  },
+  "frameworks": {
+    "dnx451": {
+      "dependencies": {
+      }
     },
-    "frameworks" : {
-        "dnx451" : {
-            "dependencies": {
-            }
-        },
-        "dnxcore50" : {
-            "dependencies": {
-                "System.Runtime": "4.0.21-beta-*"
-            }
-        }
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-*",
+        "System.Console": "4.0.0-beta-*"
+      }
     }
+  },
+  "commands": {
+    "razor-tooling": "Microsoft.AspNet.Tooling.Razor"
+  }
 }


### PR DESCRIPTION
- This is a half-baked conversion to executing the `RazorPlugin`'s `TagHelperDescriptor` resolution pieces as an executable. We don't want to fully convert to using a `Program.Main` until we have tooling support.

#25