### PR TITLE
Remove the double protocol resolving of `resolve-taghelpers`.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />

--- a/src/Microsoft.AspNet.Tooling.Razor/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Microsoft.AspNet.Tooling.Razor.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]

--- a/src/Microsoft.AspNet.Tooling.Razor/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/Properties/Resources.Designer.cs
@@ -11,6 +11,22 @@ namespace Microsoft.AspNet.Tooling.Razor
             = new ResourceManager("Microsoft.AspNet.Tooling.Razor.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// '{0}'s cannot be resolved with protocol '{1}'. Protocol not supported.
+        /// </summary>
+        internal static string InvalidProtocolValue
+        {
+            get { return GetString("InvalidProtocolValue"); }
+        }
+
+        /// <summary>
+        /// '{0}'s cannot be resolved with protocol '{1}'. Protocol not supported.
+        /// </summary>
+        internal static string FormatInvalidProtocolValue(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidProtocolValue"), p0, p1);
+        }
+
+        /// <summary>
         /// '{0}' must be provided for a '{1}' message.
         /// </summary>
         internal static string ValueMustBeProvidedInMessage

--- a/src/Microsoft.AspNet.Tooling.Razor/ResolveProtocolCommand.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/ResolveProtocolCommand.cs
@@ -14,14 +14,16 @@ namespace Microsoft.AspNet.Tooling.Razor
             {
                 config.Description = "Resolves protocol used to resolve TagHeleprDescriptors.";
                 config.HelpOption("-?|-h|--help");
-                var clientProtocol = config.Argument(
+                var clientProtocolArgument = config.Argument(
                     "[clientProtocol]",
                     "Client protocol used to consume returned TagHelperDescriptors.");
 
                 config.OnExecute(() =>
                 {
                     var pluginProtocol = new RazorPlugin(messageBroker: null).Protocol;
-                    var resolvedProtocol = ResolveProtocol(clientProtocol.Value, pluginProtocol);
+                    var clientProtocolString = clientProtocolArgument.Value;
+                    var clientProtocol = int.Parse(clientProtocolString);
+                    var resolvedProtocol = ResolveProtocol(clientProtocol, pluginProtocol);
 
                     Console.WriteLine(resolvedProtocol);
 
@@ -30,25 +32,13 @@ namespace Microsoft.AspNet.Tooling.Razor
             });
         }
 
-        public static int ResolveProtocol(CommandOption clientProtocolCommand, int pluginProtocol)
+        /// <summary>
+        /// Internal for testing.
+        /// </summary>
+        internal static int ResolveProtocol(int clientProtocol, int pluginProtocol)
         {
-            int resolvedProtocol;
-            if (clientProtocolCommand.HasValue())
-            {
-                resolvedProtocol = ResolveProtocol(clientProtocolCommand.Value(), pluginProtocol);
-            }
-            else
-            {
-                // Client protocol wasn't provided, use the plugin's protocol.
-                resolvedProtocol = pluginProtocol;
-            }
-
-            return resolvedProtocol;
-        }
-
-        private static int ResolveProtocol(string clientProtocolString, int pluginProtocol)
-        {
-            var clientProtocol = int.Parse(clientProtocolString);
+            // Protocols start at 1 and increase.
+            clientProtocol = Math.Max(1, clientProtocol);
 
             // Client and plugin protocols are max values; meaning support is <= value. The goal in this method is
             // to return the maximum protocol supported by both parties (client and plugin).

--- a/src/Microsoft.AspNet.Tooling.Razor/ResolveTagHelpersCommand.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/ResolveTagHelpersCommand.cs
@@ -24,9 +24,9 @@ namespace Microsoft.AspNet.Tooling.Razor
             {
                 config.Description = "Resolves TagHelperDescriptors in the specified assembly(s).";
                 config.HelpOption("-?|-h|--help");
-                var clientProtocol = config.Option(
+                var protocolOption = config.Option(
                     "-p|--protocol",
-                    "Provide client protocol version.",
+                    "Protocol to resolve TagHelperDescriptors with.",
                     CommandOptionType.SingleValue);
                 var assemblyNames = config.Argument(
                     "[name]",
@@ -37,9 +37,9 @@ namespace Microsoft.AspNet.Tooling.Razor
                 {
                     var messageBroker = new CommandMessageBroker();
                     var plugin = new RazorPlugin(messageBroker);
-                    var resolvedProtocol = ResolveProtocolCommand.ResolveProtocol(clientProtocol, plugin.Protocol);
+                    var protocol = int.Parse(protocolOption.Value());
 
-                    plugin.Protocol = resolvedProtocol;
+                    plugin.Protocol = protocol;
 
                     var success = true;
                     foreach (var assemblyName in assemblyNames.Values)

--- a/src/Microsoft.AspNet.Tooling.Razor/Resources.resx
+++ b/src/Microsoft.AspNet.Tooling.Razor/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidProtocolValue" xml:space="preserve">
+    <value>'{0}'s cannot be resolved with protocol '{1}'. Protocol not supported.</value>
+  </data>
   <data name="ValueMustBeProvidedInMessage" xml:space="preserve">
     <value>'{0}' must be provided for a '{1}' message.</value>
   </data>

--- a/test/Microsoft.AspNet.Tooling.Razor.Test/RazorPluginTest.cs
+++ b/test/Microsoft.AspNet.Tooling.Razor.Test/RazorPluginTest.cs
@@ -32,6 +32,34 @@ namespace Microsoft.AspNet.Tooling.Razor
                 AssemblyName = CustomTagHelperAssembly
             };
 
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(2)]
+        public void ProcessMessage_ThrowsWhenInvalidProtocol(int protocol)
+        {
+            // Arrange
+            var message = new JObject
+            {
+                { "MessageType", "SomethingThatNoOps" },
+                { "Data", new JObject() },
+            };
+            var messageBroker = new TestPluginMessageBroker();
+            var assemblyLoadContext = new TestAssemblyLoadContext();
+            var plugin = new RazorPlugin(messageBroker)
+            {
+                Protocol = protocol
+            };
+            var typeName = typeof(TagHelperDescriptor).FullName;
+            var expectedMessage =
+                $"'{typeName}'s cannot be resolved with protocol '{protocol}'. Protocol not supported.";
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => plugin.ProcessMessage(message, assemblyLoadContext));
+            Assert.Equal(expectedMessage, exception.Message, StringComparer.Ordinal);
+        }
+
         [Fact]
         public void ProcessMessage_ThrowsWhenNoMessageType()
         {

--- a/test/Microsoft.AspNet.Tooling.Razor.Test/ResolveProtocolCommandTest.cs
+++ b/test/Microsoft.AspNet.Tooling.Razor.Test/ResolveProtocolCommandTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNet.Tooling.Razor
+{
+    public class ResolveProtocolCommandTest
+    {
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(1, 3, 1)]
+        [InlineData(3, 1, 1)]
+        [InlineData(-1, 1, 1)]
+        [InlineData(23, 15, 15)]
+        public void ResolveProtocol_WorksCorrectly(int clientProtocol, int pluginProtocol, int expectedProtocol)
+        {
+            // Act
+            var resolvedProtocol = ResolveProtocolCommand.ResolveProtocol(clientProtocol, pluginProtocol);
+
+            // Assert
+            Assert.Equal(expectedProtocol, resolvedProtocol);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Tooling.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Tooling.Razor.Test/project.json
@@ -16,5 +16,8 @@
   },
   "commands": {
     "test": "xunit.runner.aspnet"
+  },
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
   }
 }


### PR DESCRIPTION
- Previously providing the `-protocol` option would re-resolve the protocol based off the `RazorPlugin`s protocol. Now the plugin uses it verbatim and throws if it has an unknown Protocol.

#31