### PR TITLE
Remove dependency on `IAssemblyLoadContext`.

### DIFF
--- a/src/Microsoft.AspNet.Tooling.Razor/AssemblyLoadContextTagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/AssemblyLoadContextTagHelperTypeResolver.cs
@@ -5,22 +5,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNet.Tooling.Razor
 {
     public class AssemblyLoadContextTagHelperTypeResolver : TagHelperTypeResolver
     {
-        private readonly IAssemblyLoadContext _assemblyLoadContext;
-
-        public AssemblyLoadContextTagHelperTypeResolver(IAssemblyLoadContext assemblyLoadContext)
-        {
-            _assemblyLoadContext = assemblyLoadContext;
-        }
-
         protected override IEnumerable<TypeInfo> GetExportedTypes(AssemblyName assemblyName)
         {
-            var assembly = _assemblyLoadContext.Load(assemblyName.FullName);
+            var assembly = Assembly.Load(assemblyName);
 
             return assembly.ExportedTypes.Select(type => type.GetTypeInfo());
         }

--- a/src/Microsoft.AspNet.Tooling.Razor/AssemblyTagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/AssemblyTagHelperDescriptorResolver.cs
@@ -6,34 +6,26 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Razor;
 using Microsoft.AspNet.Razor.Compilation.TagHelpers;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNet.Tooling.Razor
 {
     public class AssemblyTagHelperDescriptorResolver
     {
         private readonly TagHelperDescriptorFactory _descriptorFactory = new TagHelperDescriptorFactory(designTime: true);
+        private readonly TagHelperTypeResolver _tagHelperTypeResolver = new AssemblyLoadContextTagHelperTypeResolver();
 
         public int Protocol { get; set; } = 1;
 
-        public IEnumerable<TagHelperDescriptor> Resolve(
-            string assemblyName,
-            IAssemblyLoadContext assemblyLoadContext,
-            ErrorSink errorSink)
+        public IEnumerable<TagHelperDescriptor> Resolve(string assemblyName, ErrorSink errorSink)
         {
             if (assemblyName == null)
             {
                 throw new ArgumentNullException(nameof(assemblyName));
             }
 
-            if (assemblyLoadContext == null)
-            {
-                throw new ArgumentNullException(nameof(assemblyLoadContext));
-            }
-
             if (Protocol == 1)
             {
-                var tagHelperTypes = GetTagHelperTypes(assemblyName, assemblyLoadContext, errorSink);
+                var tagHelperTypes = GetTagHelperTypes(assemblyName, errorSink);
                 var tagHelperDescriptors = new List<TagHelperDescriptor>();
                 foreach (var tagHelperType in tagHelperTypes)
                 {
@@ -54,13 +46,9 @@ namespace Microsoft.AspNet.Tooling.Razor
         /// <summary>
         /// Protected virtual for testing.
         /// </summary>
-        protected virtual IEnumerable<ITypeInfo> GetTagHelperTypes(
-            string assemblyName,
-            IAssemblyLoadContext assemblyLoadContext,
-            ErrorSink errorSink)
+        protected virtual IEnumerable<ITypeInfo> GetTagHelperTypes(string assemblyName, ErrorSink errorSink)
         {
-            var tagHelperTypeResolver = new AssemblyLoadContextTagHelperTypeResolver(assemblyLoadContext);
-            var tagHelperTypes = tagHelperTypeResolver.Resolve(assemblyName, SourceLocation.Zero, errorSink);
+            var tagHelperTypes = _tagHelperTypeResolver.Resolve(assemblyName, SourceLocation.Zero, errorSink);
 
             return tagHelperTypes;
         }

--- a/src/Microsoft.AspNet.Tooling.Razor/Internal/ResolveTagHelpersCommand.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/Internal/ResolveTagHelpersCommand.cs
@@ -7,14 +7,13 @@ using System.Linq;
 using Microsoft.AspNet.Razor;
 using Microsoft.AspNet.Razor.Compilation.TagHelpers;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
-using Microsoft.Extensions.PlatformAbstractions;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNet.Tooling.Razor.Internal
 {
     public static class ResolveTagHelpersCommand
     {
-        internal static void Register(CommandLineApplication app, IAssemblyLoadContext assemblyLoadContext)
+        internal static void Register(CommandLineApplication app)
         {
             app.Command("resolve-taghelpers", config =>
             {
@@ -43,7 +42,7 @@ namespace Microsoft.AspNet.Tooling.Razor.Internal
                     for (var i = 0; i < assemblyNames.Values.Count; i++)
                     {
                         var assemblyName = assemblyNames.Values[i];
-                        var descriptors = descriptorResolver.Resolve(assemblyName, assemblyLoadContext, errorSink);
+                        var descriptors = descriptorResolver.Resolve(assemblyName, errorSink);
                         resolvedDescriptors.AddRange(descriptors);
                     }
 

--- a/src/Microsoft.AspNet.Tooling.Razor/Program.cs
+++ b/src/Microsoft.AspNet.Tooling.Razor/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.Reflection;
 using Microsoft.AspNet.Tooling.Razor.Internal;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNet.Tooling.Razor
 {
@@ -15,7 +14,6 @@ namespace Microsoft.AspNet.Tooling.Razor
         {
             try
             {
-                var loadContext = PlatformServices.Default.AssemblyLoadContextAccessor.Default;
                 var app = new CommandLineApplication
                 {
                     Name = "razor-tooling",
@@ -26,7 +24,7 @@ namespace Microsoft.AspNet.Tooling.Razor
                 app.HelpOption("-?|-h|--help");
 
                 ResolveProtocolCommand.Register(app);
-                ResolveTagHelpersCommand.Register(app, loadContext);
+                ResolveTagHelpersCommand.Register(app);
 
                 app.OnExecute(() =>
                 {

--- a/src/Microsoft.AspNet.Tooling.Razor/project.json
+++ b/src/Microsoft.AspNet.Tooling.Razor/project.json
@@ -6,10 +6,6 @@
   },
   "dependencies": {
     "Microsoft.AspNet.Razor.Runtime": "4.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": {
-      "version": "1.0.0-*",
-      "type": "build"
-    },
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "version": "1.0.0-*",
       "type": "build"
@@ -22,7 +18,6 @@
     },
     "dotnet5.4": {
       "dependencies": {
-        "System.Runtime": "4.0.21-*",
         "System.Console": "4.0.0-*"
       }
     }

--- a/test/Microsoft.AspNet.Tooling.Razor.Test/AssemblyTagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Tooling.Razor.Test/AssemblyTagHelperDescriptorResolverTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNet.Razor.Compilation.TagHelpers;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Microsoft.AspNet.Razor.Test.Internal;
-using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
 
 namespace Microsoft.AspNet.Tooling.Razor
@@ -40,7 +39,6 @@ namespace Microsoft.AspNet.Tooling.Razor
             {
                 Protocol = protocol
             };
-            var assemblyLoadContext = PlatformServices.Default.AssemblyLoadContextAccessor.Default;
             var typeName = typeof(TagHelperDescriptor).FullName;
             var errorSink = new ErrorSink();
             var expectedMessage =
@@ -48,7 +46,7 @@ namespace Microsoft.AspNet.Tooling.Razor
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(
-                () => descriptorResolver.Resolve(CustomTagHelperAssembly, assemblyLoadContext, errorSink));
+                () => descriptorResolver.Resolve(CustomTagHelperAssembly, errorSink));
             Assert.Equal(expectedMessage, exception.Message, StringComparer.Ordinal);
         }
 
@@ -56,7 +54,6 @@ namespace Microsoft.AspNet.Tooling.Razor
         public void Resolve_ResolvesTagHelperDescriptors()
         {
             // Arrange
-            var assemblyLoadContext = PlatformServices.Default.AssemblyLoadContextAccessor.Default;
             var assemblyNameLookups = new Dictionary<string, IEnumerable<ITypeInfo>>
             {
                 { CustomTagHelperAssembly, new[] { new RuntimeTypeInfo(typeof(CustomTagHelper).GetTypeInfo()) } }
@@ -65,7 +62,7 @@ namespace Microsoft.AspNet.Tooling.Razor
             var errorSink = new ErrorSink();
 
             // Act
-            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, assemblyLoadContext, errorSink);
+            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, errorSink);
 
             // Assert
             Assert.NotNull(descriptors);
@@ -79,7 +76,6 @@ namespace Microsoft.AspNet.Tooling.Razor
         public void Resolve_ResolvesDesignTimeTagHelperDescriptors()
         {
             // Arrange
-            var assemblyLoadContext = PlatformServices.Default.AssemblyLoadContextAccessor.Default;
             var assemblyNameLookups = new Dictionary<string, IEnumerable<ITypeInfo>>
             {
                 { CustomTagHelperAssembly, new[] { new RuntimeTypeInfo(typeof(DesignTimeTagHelper).GetTypeInfo()) } }
@@ -103,7 +99,7 @@ namespace Microsoft.AspNet.Tooling.Razor
             var errorSink = new ErrorSink();
 
             // Act
-            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, assemblyLoadContext, errorSink);
+            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, errorSink);
 
             // Assert
             Assert.NotNull(descriptors);
@@ -117,7 +113,6 @@ namespace Microsoft.AspNet.Tooling.Razor
         public void Resolve_CreatesErrors()
         {
             // Arrange
-            var assemblyLoadContext = PlatformServices.Default.AssemblyLoadContextAccessor.Default;
             var assemblyNameLookups = new Dictionary<string, IEnumerable<ITypeInfo>>
             {
                 { CustomTagHelperAssembly, new[] { new RuntimeTypeInfo(typeof(InvalidTagHelper).GetTypeInfo()) } }
@@ -126,7 +121,7 @@ namespace Microsoft.AspNet.Tooling.Razor
             var errorSink = new ErrorSink();
 
             // Act
-            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, assemblyLoadContext, errorSink);
+            var descriptors = descriptorResolver.Resolve(CustomTagHelperAssembly, errorSink);
 
             // Assert
             Assert.NotEmpty(descriptors);
@@ -149,10 +144,7 @@ namespace Microsoft.AspNet.Tooling.Razor
                 _assemblyTypeLookups = assemblyTypeLookups;
             }
 
-            protected override IEnumerable<ITypeInfo> GetTagHelperTypes(
-                string assemblyName,
-                IAssemblyLoadContext assemblyLoadContext,
-                ErrorSink errorSink)
+            protected override IEnumerable<ITypeInfo> GetTagHelperTypes(string assemblyName, ErrorSink errorSink)
             {
                 return _assemblyTypeLookups[assemblyName];
             }


### PR DESCRIPTION
- Transitioned to `AssemblyLoadContext`. Was able to remove a few dependencies from `project.json` but also had to rev the dotnet version to 5.5.

#29