### PR TITLE
Utilize DotnetToolDispatcher.

### DIFF
--- a/src/dotnet-razor-tooling/project.json
+++ b/src/dotnet-razor-tooling/project.json
@@ -16,6 +16,10 @@
     "Microsoft.AspNetCore.Razor.Runtime": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
+    "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
     "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {


### PR DESCRIPTION
- No longer need to build out all of the dispatching logic, it's handled by the dispatcher.
- If there's a mismatched dotnet-razor-tooling instances in the tools/dependency section the dispatcher throws on our behalf.
- Forked logic for dispatcher / dispatch recipient.
- aspnet/Common#109 adds the `DotnetToolDispatcher` which we use here.

aspnet/Coherence-Signed#276

/cc @natemcmaster @prafullbhosale 