### PR TITLE
Change dotnet-razor-tooling to netcoreapp1.0.

### DIFF
--- a/src/dotnet-razor-tooling/project.json
+++ b/src/dotnet-razor-tooling/project.json
@@ -13,7 +13,7 @@
     "xmlDoc": true
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.AspNetCore.Razor.Runtime": "1.0.0-*",
         "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-*",


### PR DESCRIPTION
- We now have a CLI that properly supports tools as netcoreapp1.0.