### PR TITLE
Add bit to repack desktop dependency to enable x86 scenarios.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -1,4 +1,12 @@
+use namespace="System.IO"
+use namespace="System.IO.Compression"
+use namespace="System.Linq"
 
+default CONFIGURATION_LOCAL='${E("Configuration")}'
+default BASE_DIR_LOCAL='${Directory.GetCurrentDirectory()}'
+default BUILD_DIR_LOCAL='${Path.Combine(BASE_DIR_LOCAL, "artifacts", "build")}'
+default TOOL_PROJECT_NAME='Microsoft.AspNetCore.Razor.Tools'
+default TOOL_EXE_NAME='dotnet-razor-tooling.exe'
 var VERSION='0.1'
 var FULL_VERSION='0.1'
 var AUTHORS='Microsoft Open Technologies, Inc.'
@@ -6,3 +14,63 @@ var AUTHORS='Microsoft Open Technologies, Inc.'
 
 use-standard-lifecycle
 k-standard-goals
+
+#repack-x86 target='compile'
+    @{    
+        if (string.IsNullOrEmpty(CONFIGURATION_LOCAL))
+        {
+            CONFIGURATION_LOCAL = "Debug";
+        }
+        
+        // Forcing to lower to match the entry in the sources project.json.
+        var configurationX86 = CONFIGURATION_LOCAL.ToLower() + "_x86";
+        
+        var projectNupkg = Files
+            .Include(Path.Combine(BUILD_DIR_LOCAL, TOOL_PROJECT_NAME + ".1.*.nupkg")) // Assuming the package version starts with 1.
+            .Where(path => !path.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(f => f)    // On local builds multiple nupkgs are generated.
+            .First();
+        
+        Log.Info("Repacking Nupkg: " + projectNupkg);
+        
+        var extractToDirectory = projectNupkg + "-temp";
+        ZipFile.ExtractToDirectory(projectNupkg, extractToDirectory);
+
+        var projectDirectory = Path.Combine(BASE_DIR_LOCAL, "src", TOOL_PROJECT_NAME);
+        var projectFilePath = Path.Combine(projectDirectory, "project.json");
+        var projectFile = Files.Include(projectFilePath).Single();
+        
+        // Generate the x86 exe variation for the nupkg.
+        DotnetBuild(projectFile, configurationX86, "net451");
+        
+        var runtimesDirectory = Path.Combine(extractToDirectory, "runtimes");
+        var win7x86Directory = Path.Combine(runtimesDirectory, "win7-x86", "lib", "net451");
+        var win7x64Directory = Path.Combine(runtimesDirectory, "win7-x64", "lib", "net451");
+        Directory.CreateDirectory(win7x86Directory);
+        Directory.CreateDirectory(win7x64Directory);
+        
+        var binDirectory = Path.Combine(projectDirectory, "bin");
+        var x86OutputPath = Path.Combine(binDirectory, configurationX86, "net451");
+        var x86ExePath = Path.Combine(x86OutputPath, TOOL_EXE_NAME);
+        var x86ExeDestinationPath = Path.Combine(win7x86Directory, TOOL_EXE_NAME);
+        File.Copy(x86ExePath, x86ExeDestinationPath);
+        
+        var x64OutputPath = Path.Combine(binDirectory, CONFIGURATION_LOCAL, "net451");
+        var x64ExePath = Path.Combine(x64OutputPath, TOOL_EXE_NAME);
+        var x64ExeDestinationPath = Path.Combine(win7x64Directory, TOOL_EXE_NAME);
+        File.Copy(x64ExePath, x64ExeDestinationPath);
+        
+        var nugetExePath = Path.Combine(BASE_DIR_LOCAL, ".build", "nuget.exe");
+        var nuspecPath = Path.Combine(extractToDirectory, TOOL_PROJECT_NAME + ".nuspec");
+        ExecClr(nugetExePath, "pack " + nuspecPath + " -OutputDirectory " + BUILD_DIR_LOCAL);
+        
+        try
+        {
+            // Delete temporary directory we used to repack.
+            Directory.Delete(extractToDirectory, true);
+        }
+        catch
+        {
+            // Don't care if we couldn't delete the temp directory.
+        }
+    }

--- a/src/Microsoft.AspNetCore.Razor.Tools/project.json
+++ b/src/Microsoft.AspNetCore.Razor.Tools/project.json
@@ -17,6 +17,18 @@
     ],
     "xmlDoc": true
   },
+  "configurations": {
+    "debug_x86": {
+      "buildOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    },
+    "release_x86": {
+      "buildOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    }
+  },
   "dependencies": {
     "Microsoft.AspNetCore.Razor.Runtime": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
@@ -43,6 +55,6 @@
         "dnxcore50"
       ]
     },
-    "net451": {}
+    "net451": { }
   }
 }


### PR DESCRIPTION
- Prior to this change we'd only ever pack the x64 variation of `dotnet-razor-tooling.exe`.
- Left the lib directory in touch for unit testing purposes.

#### Repacked Structure:
![image](https://cloud.githubusercontent.com/assets/2008729/15264589/7f92c51c-1929-11e6-9456-069101695a9a.png)

#72 

/cc @pranavkm @prafullbhosale @natemcmaster 

Nate/Prafull, feel free to take this script and modify it to fit your repos. Didn't want to put this in KoreBuild since we'd have to change each of the tool projects anyways; ultimately less repos affected.