### PR TITLE
Enable `TagHelper` resolution on unbuilt projects for non-desktop package only requests.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tools/Internal/AssemblyTagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/Internal/AssemblyTagHelperDescriptorResolver.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
 using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
-using Microsoft.AspNetCore.Razor.Tools;
 
 namespace Microsoft.AspNetCore.Razor.Tools.Internal
 {
@@ -17,8 +15,13 @@ namespace Microsoft.AspNetCore.Razor.Tools.Internal
         private readonly TagHelperTypeResolver _tagHelperTypeResolver;
 
         public AssemblyTagHelperDescriptorResolver()
+            : this(new TagHelperTypeResolver())
         {
-            _tagHelperTypeResolver = new TagHelperTypeResolver();
+        }
+
+        public AssemblyTagHelperDescriptorResolver(TagHelperTypeResolver tagHelperTypeResolver)
+        {
+            _tagHelperTypeResolver = tagHelperTypeResolver;
         }
 
         public static int DefaultProtocolVersion { get; } = 1;

--- a/src/Microsoft.AspNetCore.Razor.Tools/Internal/PackageOnlyResolveTagHelpersRunCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/Internal/PackageOnlyResolveTagHelpersRunCommand.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETCOREAPP1_0
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Loader;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Frameworks;
+
+namespace Microsoft.AspNetCore.Razor.Tools.Internal
+{
+    public class PackageOnlyResolveTagHelpersRunCommand : ResolveTagHelpersRunCommand
+    {
+        private readonly TagHelperTypeResolver packageTagHelperTypeResolver;
+
+        public PackageOnlyResolveTagHelpersRunCommand(AssemblyLoadContext loadContext)
+        {
+            packageTagHelperTypeResolver = new PackageTagHelperTypeResolver(loadContext);
+        }
+
+        protected override AssemblyTagHelperDescriptorResolver CreateDescriptorResolver() =>
+            new AssemblyTagHelperDescriptorResolver(packageTagHelperTypeResolver);
+
+        public static bool TryPackageOnlyTagHelperResolution(
+            CommandArgument assemblyNamesArgument,
+            CommandOption protocolOption,
+            CommandOption buildBasePathOption,
+            CommandOption configurationOption,
+            Project project,
+            NuGetFramework framework,
+            out int exitCode)
+        {
+            exitCode = 0;
+
+            if (framework.IsDesktop())
+            {
+                return false;
+            }
+
+            var runtimeIdentifiers = RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers();
+            var projectContext = new ProjectContextBuilder()
+                .WithProject(project)
+                .WithTargetFramework(framework)
+                .WithRuntimeIdentifiers(runtimeIdentifiers)
+                .Build();
+            var configuration = configurationOption.Value() ?? Constants.DefaultConfiguration;
+
+            var projectRuntimeOutputPath = projectContext.GetOutputPaths(configuration, buildBasePathOption.Value())?.RuntimeOutputPath;
+            var projectAssemblyName = project.GetCompilerOptions(framework, configuration).OutputName;
+            var projectOutputAssembly = Path.Combine(projectRuntimeOutputPath, projectAssemblyName + ".dll");
+
+            if (File.Exists(projectOutputAssembly))
+            {
+                // There's already build output. Dispatch to build output; this ensures dependencies have been resolved.
+                return false;
+            }
+
+            var projectLibraries = projectContext.LibraryManager.GetLibraries();
+            var libraryLookup = projectLibraries.ToDictionary(
+                library => library.Identity.Name,
+                library => library,
+                StringComparer.Ordinal);
+
+            foreach (var assemblyName in assemblyNamesArgument.Values)
+            {
+                if (!IsPackageOnly(assemblyName, libraryLookup))
+                {
+                    return false;
+                }
+            }
+
+            var loadContext = projectContext.CreateLoadContext();
+            var runner = new PackageOnlyResolveTagHelpersRunCommand(loadContext)
+            {
+                AssemblyNamesArgument = assemblyNamesArgument,
+                ProtocolOption = protocolOption
+            };
+
+            exitCode = runner.OnExecute();
+
+            return true;
+        }
+
+        private static bool IsPackageOnly(string libraryName, IDictionary<string, LibraryDescription> libraryLookup)
+        {
+            LibraryDescription library;
+            if (!libraryLookup.TryGetValue(libraryName, out library) ||
+                library.Identity.Type != LibraryType.Package)
+            {
+                return false;
+            }
+
+            foreach (var dependency in library.Dependencies)
+            {
+                if (!IsPackageOnly(dependency.Name, libraryLookup))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private class PackageTagHelperTypeResolver : TagHelperTypeResolver
+        {
+            private readonly AssemblyLoadContext _loadContext;
+
+            public PackageTagHelperTypeResolver(AssemblyLoadContext loadContext)
+            {
+                _loadContext = loadContext;
+            }
+
+            protected override IEnumerable<TypeInfo> GetExportedTypes(AssemblyName assemblyName)
+            {
+                var assembly = _loadContext.LoadFromAssemblyName(assemblyName);
+                var exportedTypes = assembly.ExportedTypes;
+                var exportedTypeInfos = exportedTypes.Select(type => type.GetTypeInfo());
+
+                return exportedTypeInfos;
+            }
+        }
+    }
+}
+#endif

--- a/src/Microsoft.AspNetCore.Razor.Tools/Internal/ResolveTagHelpersRunCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/Internal/ResolveTagHelpersRunCommand.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
-using Microsoft.AspNetCore.Razor.Tools;
 
 namespace Microsoft.AspNetCore.Razor.Tools.Internal
 {
@@ -32,10 +30,8 @@ namespace Microsoft.AspNetCore.Razor.Tools.Internal
                 protocol = AssemblyTagHelperDescriptorResolver.DefaultProtocolVersion;
             }
 
-            var descriptorResolver = new AssemblyTagHelperDescriptorResolver()
-            {
-                ProtocolVersion = protocol
-            };
+            var descriptorResolver = CreateDescriptorResolver();
+            descriptorResolver.ProtocolVersion = protocol;
 
             var errorSink = new ErrorSink();
             var resolvedDescriptors = new List<TagHelperDescriptor>();
@@ -50,5 +46,8 @@ namespace Microsoft.AspNetCore.Razor.Tools.Internal
 
             return 0;
         }
+
+        protected virtual AssemblyTagHelperDescriptorResolver CreateDescriptorResolver() =>
+            new AssemblyTagHelperDescriptorResolver();
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Tools/project.json
+++ b/src/Microsoft.AspNetCore.Razor.Tools/project.json
@@ -43,6 +43,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
+        "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-*",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-*"


### PR DESCRIPTION
- Desktop requests would require that the tool be booted in desktop, therefore we can't resolve TagHelpers without dispatching in some form. If a packages entire graph is package based then we can ensure that a call to `AssemblyLoadContext.Load` returns loaded bits from the .nuget/packages folder on the current box.
- Can't easily automate tests due to lack of end-to-end infrastructure dictated by #62.

#70

/cc @natemcmaster @prafullbhosale 