### PR TITLE
Add end-to-end functional tests.

### DIFF
--- a/RazorTooling.TestApps.sln
+++ b/RazorTooling.TestApps.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testapps", "testapps", "{0FEA34D0-789B-43BF-BBA3-CD92D56321A4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B8E45335-6D2E-45DE-BED5-D48E67D0DC45}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		NuGet.config = NuGet.config
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorToolingTestApp.Library", "testapps\RazorToolingTestApp.Library\RazorToolingTestApp.Library.xproj", "{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorToolingTestApp", "testapps\RazorToolingTestApp\RazorToolingTestApp.xproj", "{2F254FF7-6B16-4C1C-8683-0D21C887611E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0A6865A4-0097-43B8-8579-9D4ADF2012DA}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorToolingTestApp.LibraryPackage", "src\RazorToolingTestApp.LibraryPackage\RazorToolingTestApp.LibraryPackage.xproj", "{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F254FF7-6B16-4C1C-8683-0D21C887611E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F254FF7-6B16-4C1C-8683-0D21C887611E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F254FF7-6B16-4C1C-8683-0D21C887611E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F254FF7-6B16-4C1C-8683-0D21C887611E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731} = {0FEA34D0-789B-43BF-BBA3-CD92D56321A4}
+		{2F254FF7-6B16-4C1C-8683-0D21C887611E} = {0FEA34D0-789B-43BF-BBA3-CD92D56321A4}
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B} = {0A6865A4-0097-43B8-8579-9D4ADF2012DA}
+	EndGlobalSection
+EndGlobal

--- a/RazorTooling.sln
+++ b/RazorTooling.sln
@@ -18,6 +18,14 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Razor.Design.Test", "test\Microsoft.AspNetCore.Razor.Design.Test\Microsoft.AspNetCore.Razor.Design.Test.xproj", "{C4279BCD-DADD-4354-B28D-B7FE24BAD230}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Razor.Tools.Test", "test\Microsoft.AspNetCore.Razor.Tools.Test\Microsoft.AspNetCore.Razor.Tools.Test.xproj", "{D0754BC0-B357-4ABD-8964-00F61BE15CDD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testapps", "testapps", "{55C25CA3-70A9-41BC-A0D5-7B44D06CC6CD}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorToolingTestApp.Library", "testapps\RazorToolingTestApp.Library\RazorToolingTestApp.Library.xproj", "{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorToolingTestApp.LibraryPackage", "src\RazorToolingTestApp.LibraryPackage\RazorToolingTestApp.LibraryPackage.xproj", "{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		debug_x86|Any CPU = debug_x86|Any CPU
@@ -50,6 +58,30 @@ Global
 		{C4279BCD-DADD-4354-B28D-B7FE24BAD230}.release_x86|Any CPU.Build.0 = Release|Any CPU
 		{C4279BCD-DADD-4354-B28D-B7FE24BAD230}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4279BCD-DADD-4354-B28D-B7FE24BAD230}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.release_x86|Any CPU.ActiveCfg = Release|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.release_x86|Any CPU.Build.0 = Release|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.release_x86|Any CPU.ActiveCfg = Release|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.release_x86|Any CPU.Build.0 = Release|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.debug_x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.debug_x86|Any CPU.Build.0 = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.release_x86|Any CPU.ActiveCfg = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.release_x86|Any CPU.Build.0 = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,5 +90,8 @@ Global
 		{6F1CAB8C-2315-46BB-B9B4-00564743590C} = {253024B2-368B-4B24-9CD3-D48E9C1EC948}
 		{60043E40-0D14-4E41-A97A-52A7A1BB5A26} = {253024B2-368B-4B24-9CD3-D48E9C1EC948}
 		{C4279BCD-DADD-4354-B28D-B7FE24BAD230} = {8D49C692-BA71-43C4-927F-E9E2BA8FC795}
+		{D0754BC0-B357-4ABD-8964-00F61BE15CDD} = {8D49C692-BA71-43C4-927F-E9E2BA8FC795}
+		{CF8D2020-2F4C-4C9F-9B5E-76A0A3E33731} = {55C25CA3-70A9-41BC-A0D5-7B44D06CC6CD}
+		{DAE3EE34-5C21-4A05-8C0F-2DD1C18BB25B} = {253024B2-368B-4B24-9CD3-D48E9C1EC948}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "projects": [ "src" ]
+  "projects": [ "src", "testapps" ]
 }

--- a/makefile.shade
+++ b/makefile.shade
@@ -2,11 +2,13 @@ use namespace="System.IO"
 use namespace="System.IO.Compression"
 use namespace="System.Linq"
 
-default CONFIGURATION_LOCAL='${E("Configuration")}'
 default BASE_DIR_LOCAL='${Directory.GetCurrentDirectory()}'
 default BUILD_DIR_LOCAL='${Path.Combine(BASE_DIR_LOCAL, "artifacts", "build")}'
 default TOOL_PROJECT_NAME='Microsoft.AspNetCore.Razor.Design'
 default TOOL_EXE_NAME='Microsoft.AspNetCore.Razor.Design.exe'
+default TEST_PROJECT_PACKAGE_NAME='RazorToolingTestApp.LibraryPackage'
+default TEST_ARTIFACTS_DIR='${Path.Combine(BASE_DIR_LOCAL, "testartifacts")}'
+default TEST_ARTIFACTS_INITIAL_PACKAGE_DIR='${Path.Combine(TEST_ARTIFACTS_DIR, "initialpackages")}'
 var VERSION='0.1'
 var FULL_VERSION='0.1'
 var AUTHORS='Microsoft Open Technologies, Inc.'
@@ -15,13 +17,25 @@ var AUTHORS='Microsoft Open Technologies, Inc.'
 use-standard-lifecycle
 k-standard-goals
 
+default CONFIGURATION_LOCAL='${E("Configuration")}'
+
+#pack-test-dependencies target='repo-initialize'
+    rimraf rimrafDir='${TEST_ARTIFACTS_INITIAL_PACKAGE_DIR}' if='Directory.Exists(TEST_ARTIFACTS_INITIAL_PACKAGE_DIR)'
+
+    @{
+        Directory.CreateDirectory(TEST_ARTIFACTS_INITIAL_PACKAGE_DIR);
+        var projectDirectory = Path.Combine(BASE_DIR_LOCAL, "src", TEST_PROJECT_PACKAGE_NAME);
+        
+        Dotnet("restore " + projectDirectory);
+        Dotnet("pack " + projectDirectory + " -o " + TEST_ARTIFACTS_INITIAL_PACKAGE_DIR);
+
+        // Restore testapps folder locally to ensure all dynamically generated packages have been cached. 
+        var testProjectDirectory = Path.Combine(BASE_DIR_LOCAL, "testapps");
+        Dotnet("restore " + testProjectDirectory + " -f " + TEST_ARTIFACTS_INITIAL_PACKAGE_DIR);
+    }
+
 #repack-x86 target='compile' if='Directory.Exists("src")'
     @{
-        if (string.IsNullOrEmpty(CONFIGURATION_LOCAL))
-        {
-            CONFIGURATION_LOCAL = "Debug";
-        }
-        
         // Forcing to lower to match the entry in the sources project.json.
         var configurationX86 = CONFIGURATION_LOCAL.ToLower() + "_x86";
         
@@ -78,3 +92,7 @@ k-standard-goals
             // Don't care if we couldn't delete the temp directory.
         }
     }
+
+
+macro name="DotnetRestore" restoreDir='string'
+    dotnet-restore

--- a/src/Microsoft.AspNetCore.Razor.Design/Internal/ResolvedTagHelperDescriptorsResult.cs
+++ b/src/Microsoft.AspNetCore.Razor.Design/Internal/ResolvedTagHelperDescriptorsResult.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Design.Internal
+{
+    public class ResolvedTagHelperDescriptorsResult
+    {
+        public IEnumerable<TagHelperDescriptor> Descriptors { get; set; }
+
+        public IEnumerable<RazorError> Errors { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Design/ResolveTagHelpersCommandBase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Design/ResolveTagHelpersCommandBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+using Microsoft.AspNetCore.Razor.Design.Internal;
 using Microsoft.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
 
@@ -69,13 +70,6 @@ namespace Microsoft.AspNetCore.Razor.Design
 
                 config.OnExecute((Func<int>)OnExecute);
             });
-        }
-
-        private class ResolvedTagHelperDescriptorsResult
-        {
-            public IEnumerable<TagHelperDescriptor> Descriptors { get; set; }
-
-            public IEnumerable<RazorError> Errors { get; set; }
         }
     }
 }

--- a/src/RazorToolingTestApp.LibraryPackage/RazorToolingTestApp.LibraryPackage.xproj
+++ b/src/RazorToolingTestApp.LibraryPackage/RazorToolingTestApp.LibraryPackage.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>dae3ee34-5c21-4a05-8c0f-2dd1c18bb25b</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/RazorToolingTestApp.LibraryPackage/TestTagHelperTypes.cs
+++ b/src/RazorToolingTestApp.LibraryPackage/TestTagHelperTypes.cs
@@ -1,0 +1,371 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace RazorToolingTestApp.LibraryPackage
+{
+    // These set of TagHelpers were pulled from pieces Razor tests. They're here to ensure we cover as many scenarios
+    // as possible.
+
+    public enum CustomEnum
+    {
+        FirstValue,
+        SecondValue
+    }
+
+    public class EnumTagHelper : TagHelper
+    {
+        public int NonEnumProperty { get; set; }
+
+        public CustomEnum EnumProperty { get; set; }
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("input")]
+    public class MultiEnumTagHelper : EnumTagHelper
+    {
+    }
+
+    [HtmlTargetElement("input", ParentTag = "div")]
+    public class RequiredParentTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p", ParentTag = "div")]
+    [HtmlTargetElement("input", ParentTag = "section")]
+    public class MultiSpecifiedRequiredParentTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("input", ParentTag = "div")]
+    public class MultiWithUnspecifiedRequiredParentTagHelper : TagHelper
+    {
+    }
+
+
+    [RestrictChildren("p")]
+    public class RestrictChildrenTagHelper
+    {
+    }
+
+    [RestrictChildren("p", "strong")]
+    public class DoubleRestrictChildrenTagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
+    [RestrictChildren("p", "strong")]
+    public class MultiTargetRestrictChildrenTagHelper
+    {
+    }
+
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    public class TagStructureTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p", TagStructure = TagStructure.NormalOrSelfClosing)]
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    public class MultiSpecifiedTagStructureTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    public class MultiWithUnspecifiedTagStructureTagHelper : TagHelper
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    public class DefaultEditorBrowsableTagHelper : TagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        public int Property { get; set; }
+    }
+
+    public class HiddenPropertyEditorBrowsableTagHelper : TagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Property { get; set; }
+    }
+
+    public class MultiPropertyEditorBrowsableTagHelper : TagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Property { get; set; }
+
+        public virtual int Property2 { get; set; }
+    }
+
+    public class OverriddenPropertyEditorBrowsableTagHelper : MultiPropertyEditorBrowsableTagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int Property2 { get; set; }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class EditorBrowsableTagHelper : TagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual int Property { get; set; }
+    }
+
+    public class InheritedEditorBrowsableTagHelper : EditorBrowsableTagHelper
+    {
+        public override int Property { get; set; }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public class OverriddenEditorBrowsableTagHelper : EditorBrowsableTagHelper
+    {
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public override int Property { get; set; }
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class MultiEditorBrowsableTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "class*")]
+    public class AttributeWildcardTargetingTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "class*,style*")]
+    public class MultiAttributeWildcardTargetingTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "class")]
+    public class AttributeTargetingTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "class,style")]
+    public class MultiAttributeTargetingTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "custom")]
+    [HtmlTargetElement(Attributes = "class,style")]
+    public class MultiAttributeAttributeTargetingTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement(Attributes = "style")]
+    public class InheritedAttributeTargetingTagHelper : AttributeTargetingTagHelper
+    {
+    }
+
+    [HtmlTargetElement("input", Attributes = "class")]
+    public class RequiredAttributeTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("div", Attributes = "class")]
+    public class InheritedRequiredAttributeTagHelper : RequiredAttributeTagHelper
+    {
+    }
+
+    [HtmlTargetElement("div", Attributes = "class")]
+    [HtmlTargetElement("input", Attributes = "class")]
+    public class MultiAttributeRequiredAttributeTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("input", Attributes = "style")]
+    [HtmlTargetElement("input", Attributes = "class")]
+    public class MultiAttributeSameTagRequiredAttributeTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("input", Attributes = "class,style")]
+    public class MultiRequiredAttributeTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("div", Attributes = "style")]
+    public class InheritedMultiRequiredAttributeTagHelper : MultiRequiredAttributeTagHelper
+    {
+    }
+
+    [HtmlTargetElement("div", Attributes = "class,style")]
+    [HtmlTargetElement("input", Attributes = "class,style")]
+    public class MultiTagMultiRequiredAttributeTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
+    public class MultiTagTagHelper
+    {
+        public string ValidAttribute { get; set; }
+    }
+
+    public class InheritedMultiTagTagHelper : MultiTagTagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
+    [HtmlTargetElement("div")]
+    public class DuplicateTagNameTagHelper
+    {
+    }
+
+    [HtmlTargetElement("data-condition")]
+    public class OverrideNameTagHelper
+    {
+    }
+
+    public class DuplicateAttributeNameTagHelper
+    {
+        public string MyNameIsLegion { get; set; }
+
+        [HtmlAttributeName("my-name-is-legion")]
+        public string Fred { get; set; }
+    }
+
+    public class NotBoundAttributeTagHelper
+    {
+        public object BoundProperty { get; set; }
+
+        [HtmlAttributeNotBound]
+        public string NotBoundProperty { get; set; }
+
+        [HtmlAttributeName("unused")]
+        [HtmlAttributeNotBound]
+        public string NamedNotBoundProperty { get; set; }
+    }
+
+    public class OverriddenAttributeTagHelper
+    {
+        [HtmlAttributeName("SomethingElse")]
+        public virtual string ValidAttribute1 { get; set; }
+
+        [HtmlAttributeName("Something-Else")]
+        public string ValidAttribute2 { get; set; }
+    }
+
+    public class InheritedOverriddenAttributeTagHelper : OverriddenAttributeTagHelper
+    {
+        public override string ValidAttribute1 { get; set; }
+    }
+
+    public class InheritedNotOverriddenAttributeTagHelper : OverriddenAttributeTagHelper
+    {
+    }
+
+    public class ALLCAPSTAGHELPER : TagHelper
+    {
+        public int ALLCAPSATTRIBUTE { get; set; }
+    }
+
+    public class CAPSOnOUTSIDETagHelper : TagHelper
+    {
+        public int CAPSOnOUTSIDEATTRIBUTE { get; set; }
+    }
+
+    public class capsONInsideTagHelper : TagHelper
+    {
+        public int capsONInsideattribute { get; set; }
+    }
+
+    public class One1Two2Three3TagHelper : TagHelper
+    {
+        public int One1Two2Three3Attribute { get; set; }
+    }
+
+    public class ONE1TWO2THREE3TagHelper : TagHelper
+    {
+        public int ONE1TWO2THREE3Attribute { get; set; }
+    }
+
+    public class First_Second_ThirdHiTagHelper : TagHelper
+    {
+        public int First_Second_ThirdAttribute { get; set; }
+    }
+
+    public class UNSuffixedCLASS : TagHelper
+    {
+        public int UNSuffixedATTRIBUTE { get; set; }
+    }
+
+    public class DefaultValidHtmlAttributePrefix : TagHelper
+    {
+        public IDictionary<string, string> DictionaryProperty { get; set; }
+    }
+
+    public class SingleValidHtmlAttributePrefix : TagHelper
+    {
+        [HtmlAttributeName("valid-name")]
+        public IDictionary<string, string> DictionaryProperty { get; set; }
+    }
+
+    public class MultipleValidHtmlAttributePrefix : TagHelper
+    {
+        [HtmlAttributeName("valid-name1", DictionaryAttributePrefix = "valid-prefix1-")]
+        public Dictionary<string, object> DictionaryProperty { get; set; }
+
+        [HtmlAttributeName("valid-name2", DictionaryAttributePrefix = "valid-prefix2-")]
+        public DictionarySubclass DictionarySubclassProperty { get; set; }
+
+        [HtmlAttributeName("valid-name3", DictionaryAttributePrefix = "valid-prefix3-")]
+        public DictionaryWithoutParameterlessConstructor DictionaryWithoutParameterlessConstructorProperty { get; set; }
+
+        [HtmlAttributeName("valid-name4", DictionaryAttributePrefix = "valid-prefix4-")]
+        public GenericDictionarySubclass<object> GenericDictionarySubclassProperty { get; set; }
+
+        [HtmlAttributeName("valid-name5", DictionaryAttributePrefix = "valid-prefix5-")]
+        public SortedDictionary<string, int> SortedDictionaryProperty { get; set; }
+
+        [HtmlAttributeName("valid-name6")]
+        public string StringProperty { get; set; }
+
+        public IDictionary<string, int> GetOnlyDictionaryProperty { get; }
+
+        [HtmlAttributeName(DictionaryAttributePrefix = "valid-prefix6")]
+        public IDictionary<string, string> GetOnlyDictionaryPropertyWithAttributePrefix { get; }
+    }
+
+    public class DictionarySubclass : Dictionary<string, string>
+    {
+    }
+
+    public class DictionaryWithoutParameterlessConstructor : Dictionary<string, string>
+    {
+        public DictionaryWithoutParameterlessConstructor(int count)
+            : base()
+        {
+        }
+    }
+
+    public class DictionaryOfIntSubclass : Dictionary<int, string>
+    {
+    }
+
+    public class GenericDictionarySubclass<TValue> : Dictionary<string, TValue>
+    {
+    }
+
+    [OutputElementHint("strong")]
+    public class OutputElementHintTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("a")]
+    [HtmlTargetElement("p")]
+    [OutputElementHint("div")]
+    public class MulitpleDescriptorTagHelperWithOutputElementHint : TagHelper
+    {
+    }
+}

--- a/src/RazorToolingTestApp.LibraryPackage/project.json
+++ b/src/RazorToolingTestApp.LibraryPackage/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "version": "1.0.0",
+
+  "dependencies": {
+    "Microsoft.AspNetCore.Razor.Runtime": "1.1.0-*"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0-*"
+      }
+    },
+    "net451": {}
+  }
+}

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ToolTestFixture.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ToolTestFixture.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Tools.Test.Infrastructure
+{
+    public class ToolTestFixture : IDisposable
+    {
+        private readonly string _defaultNugetPackageLocation;
+
+        public ToolTestFixture()
+        {
+            PackSrcDirectory();
+
+            _defaultNugetPackageLocation = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", TestArtifactsTempPackagesDirectory);
+
+            InitializeTestApps();
+        }
+
+        public string RootDirectory => Path.GetFullPath(Path.Combine("..", ".."));
+
+        public string SrcDirectory => Path.Combine(RootDirectory, "src");
+
+        public string TestArtifactsDirectoryName => "testartifacts";
+
+        public string TestArtifactsDirectory => Path.Combine(RootDirectory, TestArtifactsDirectoryName);
+
+        public string TestArtifactsTempSrcPackagesDirectory => Path.Combine(TestArtifactsDirectory, "srcpackages");
+
+        public string TestArtifactsInitialPackagesDirectory => Path.Combine(TestArtifactsDirectory, "initialpackages");
+
+        public string TestArtifactsTempPackagesDirectory => Path.Combine(TestArtifactsDirectory, "packages");
+
+        public string TestAppDirectory => Path.Combine(RootDirectory, "testapps");
+
+        public StringBuilder DotNet(string projectDirectory, string commandName, params string[] args)
+        {
+            var command = Command.CreateDotNet(commandName, args);
+            var outputWriter = new StringWriter();
+
+            var exitCode = command
+                .ForwardStdErr(outputWriter)
+                .ForwardStdOut(outputWriter)
+                .WorkingDirectory(projectDirectory)
+                .Execute()
+                .ExitCode;
+
+            var outputBuilder = outputWriter.GetStringBuilder();
+
+            if (exitCode != 0)
+            {
+                Assert.True(false, outputBuilder.ToString());
+            }
+
+            return outputBuilder;
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", _defaultNugetPackageLocation);
+            Directory.Delete(TestArtifactsTempPackagesDirectory, recursive: true);
+            Directory.Delete(TestArtifactsTempSrcPackagesDirectory, recursive: true);
+        }
+
+        private void PackSrcDirectory()
+        {
+            Console.WriteLine("Packing src projects...");
+
+            DotNet(SrcDirectory, "restore");
+
+            foreach (var directory in Directory.EnumerateDirectories(SrcDirectory))
+            {
+                DotNet(directory, "pack", "-o", TestArtifactsTempSrcPackagesDirectory);
+            }
+
+            Console.WriteLine("Done.");
+        }
+
+        private void InitializeTestApps()
+        {
+            var outputWriter = new StringWriter();
+            var outputBuilder = outputWriter.GetStringBuilder();
+
+            if (Directory.Exists(TestArtifactsTempPackagesDirectory))
+            {
+                Directory.Delete(TestArtifactsTempPackagesDirectory, recursive: true);
+            }
+
+            var nugetConfigXmlLocation = Path.Combine(RootDirectory, "NuGet.config");
+            var nugetConfigXml = XDocument.Load(nugetConfigXmlLocation);
+            var addElements = nugetConfigXml
+                .Root
+                .Element("packageSources")
+                .Elements("add");
+            var nugetConfigSources = new List<string>
+            {
+                "-s",
+                TestArtifactsTempSrcPackagesDirectory,
+                "-s",
+                TestArtifactsInitialPackagesDirectory,
+            };
+            foreach (var element in addElements)
+            {
+                nugetConfigSources.Add("-s");
+                var source = element.Attribute("value").Value;
+
+                nugetConfigSources.Add(source);
+            }
+
+            foreach (var testProjectDirectory in Directory.EnumerateDirectories(TestAppDirectory))
+            {
+                Console.WriteLine($"Initializing test app {Path.GetFileName(testProjectDirectory)}.");
+
+                DotNet(testProjectDirectory, "restore", nugetConfigSources.ToArray());
+
+                Console.WriteLine("Done.");
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ToolTestFixtureDefinition.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ToolTestFixtureDefinition.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Tools.Test.Infrastructure
+{
+    [CollectionDefinition(nameof(ToolTestFixture))]
+    public class ToolTestFixtureDefinition : ICollectionFixture<ToolTestFixture>
+    {
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.xproj
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/Microsoft.AspNetCore.Razor.Tools.Test.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d0754bc0-b357-4abd-8964-00f61be15cdd</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/ResolveTagHelperTests.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/ResolveTagHelperTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Razor.Design.Internal;
+using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+using Microsoft.AspNetCore.Razor.Test.Internal;
+using Microsoft.AspNetCore.Razor.Tools.Test.Infrastructure;
+using Microsoft.AspNetCore.Testing.xunit;
+using Newtonsoft.Json;
+using RazorToolingTestApp.Library;
+using RazorToolingTestApp.LibraryPackage;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Tools.Test
+{
+    [Collection(nameof(ToolTestFixture))]
+    public class ResolveTagHelperTests
+    {
+        private const string TestProjectName = "RazorToolingTestApp";
+        private const string TestTagHelperProjectName = TestProjectName + ".Library";
+
+        public ResolveTagHelperTests(ToolTestFixture toolTestFixture)
+        {
+            Fixture = toolTestFixture;
+        }
+
+        public ToolTestFixture Fixture { get; }
+
+        public string TestProjectDirectory => Path.Combine(Fixture.TestAppDirectory, TestProjectName);
+
+        public string TestProjectFile => Path.Combine(TestProjectDirectory, "project.json");
+
+        [Fact]
+        public void ResolveTagHelpersGeneratesExpectedOutput_WithDefaultParameters()
+        {
+            // Act & Assert
+            ResolveTagHelpersGeneratesExpectedOutput();
+        }
+
+        [Fact]
+        public void ResolveTagHelpersGeneratesExpectedOutput_WithNetCoreAppFramework()
+        {
+            // Act & Assert
+            ResolveTagHelpersGeneratesExpectedOutput("-f", "netcoreapp1.0");
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+
+        public void ResolveTagHelpersGeneratesExpectedOutput_WithDesktopFramework()
+        {
+            // Act & Assert
+            ResolveTagHelpersGeneratesExpectedOutput("-f", "net451");
+        }
+
+        [Theory]
+        [InlineData("Debug")]
+        [InlineData("Release")]
+        public void ResolveTagHelpersGeneratesExpectedOutput_WithConfiguration(string configuration)
+        {
+            // Act & Assert
+            ResolveTagHelpersGeneratesExpectedOutput("-c", configuration);
+        }
+
+        [Fact]
+        public void ResolveTagHelpersGeneratesExpectedOutput_WithBuildBasePath()
+        {
+            // Arrange
+            var testBin = Path.Combine(Fixture.TestArtifactsDirectory, "testbin");
+
+            // Act & Assert
+            ResolveTagHelpersGeneratesExpectedOutput("-b", testBin);
+        }
+
+        [Fact]
+        public void ResolveTagHelpersDoesNotDispatchForPackageAssemblies()
+        {
+            // Arrange
+            var tagHelperAssemblyName = typeof(MultiEnumTagHelper).GetTypeInfo().Assembly.GetName().Name;
+            var tagHelperDescriptorFactory = new TagHelperDescriptorFactory(designTime: true);
+            var tagHelperTypeResolver = new TagHelperTypeResolver();
+            var errorSink = new ErrorSink();
+            var tagHelperTypes = tagHelperTypeResolver.Resolve(tagHelperAssemblyName, SourceLocation.Zero, errorSink);
+            var expectedDescriptors = tagHelperTypes.SelectMany(type =>
+                tagHelperDescriptorFactory.CreateDescriptors(tagHelperAssemblyName, type, errorSink));
+
+            // Ensure descriptors were determined without error.
+            Assert.Empty(errorSink.Errors);
+
+            // Act
+            var output = DotNet(
+                "razor-tooling",
+                "resolve-taghelpers",
+                TestProjectFile,
+                tagHelperAssemblyName,
+                "-b",
+                "doesnotexist").ToString();
+
+            // Assert
+            var resolveTagHelpersResult = JsonConvert.DeserializeObject<ResolvedTagHelperDescriptorsResult>(output);
+            Assert.Empty(resolveTagHelpersResult.Errors);
+            Assert.Equal(
+                expectedDescriptors,
+                resolveTagHelpersResult.Descriptors,
+                CaseSensitiveTagHelperDescriptorComparer.Default);
+        }
+
+        [Fact]
+        public void ResolveTagHelpersDispatchesForPackageAssembliesIfAppIsBuilt()
+        {
+            // Arrange
+            DotNet("build");
+
+            var tagHelperAssemblyName = typeof(MultiEnumTagHelper).GetTypeInfo().Assembly.GetName().Name;
+            var tagHelperDescriptorFactory = new TagHelperDescriptorFactory(designTime: true);
+            var tagHelperTypeResolver = new TagHelperTypeResolver();
+            var errorSink = new ErrorSink();
+            var tagHelperTypes = tagHelperTypeResolver.Resolve(tagHelperAssemblyName, SourceLocation.Zero, errorSink);
+            var expectedDescriptors = tagHelperTypes.SelectMany(type =>
+                tagHelperDescriptorFactory.CreateDescriptors(tagHelperAssemblyName, type, errorSink));
+
+            // Ensure descriptors were determined without error.
+            Assert.Empty(errorSink.Errors);
+
+            // Act
+            var output = DotNet(
+                "razor-tooling",
+                "resolve-taghelpers",
+                TestProjectFile,
+                tagHelperAssemblyName).ToString();
+
+            // Assert
+            var resolveTagHelpersResult = JsonConvert.DeserializeObject<ResolvedTagHelperDescriptorsResult>(output);
+            Assert.Empty(resolveTagHelpersResult.Errors);
+            Assert.Equal(
+                expectedDescriptors,
+                resolveTagHelpersResult.Descriptors,
+                CaseSensitiveTagHelperDescriptorComparer.Default);
+        }
+
+        private void ResolveTagHelpersGeneratesExpectedOutput(params string[] buildArgs)
+        {
+            // Build the project so TagHelpers can be resolved.
+            DotNet("build", buildArgs);
+
+            var tagHelperDescriptorFactory = new TagHelperDescriptorFactory(designTime: true);
+            var errorSink = new ErrorSink();
+            var expectedDescriptors = tagHelperDescriptorFactory.CreateDescriptors(
+                TestTagHelperProjectName,
+                typeof(InformationalTagHelper),
+                errorSink);
+            var resolveArgs = new[] { "resolve-taghelpers", TestProjectFile, TestTagHelperProjectName }
+                .Concat(buildArgs)
+                .ToArray();
+
+            // Ensure no errors were created on descriptor creation.
+            Assert.Empty(errorSink.Errors);
+
+            var output = DotNet("razor-tooling", resolveArgs).ToString();
+
+            var resolveTagHelpersResult = JsonConvert.DeserializeObject<ResolvedTagHelperDescriptorsResult>(output);
+            Assert.Empty(resolveTagHelpersResult.Errors);
+            Assert.Equal(
+                expectedDescriptors,
+                resolveTagHelpersResult.Descriptors,
+                CaseSensitiveTagHelperDescriptorComparer.Default);
+        }
+
+        private StringBuilder DotNet(string commandName, params string[] args) =>
+            Fixture.DotNet(TestProjectDirectory, commandName, args);
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/project.json
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/project.json
@@ -1,0 +1,29 @@
+{
+  "testRunner": "xunit",
+  "dependencies": {
+    "dotnet-test-xunit": "2.2.0-*",
+    "Microsoft.AspNetCore.Razor.Test.Sources": {
+      "version": "1.1.0-*",
+      "type": "build"
+    },
+    "Microsoft.AspNetCore.Razor.Tools": "1.0.0-*",
+    "Microsoft.AspNetCore.Testing": "1.1.0-*",
+    "Microsoft.Extensions.HashCodeCombiner.Sources": {
+      "version": "1.1.0-*",
+      "type": "build"
+    },
+    "RazorToolingTestApp.Library": "1.0.0",
+    "RazorToolingTestApp.LibraryPackage": "1.0.0",
+    "xunit": "2.2.0-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        }
+      }
+    }
+  }
+}

--- a/testapps/RazorToolingTestApp.Library/InformationalTagHelper.cs
+++ b/testapps/RazorToolingTestApp.Library/InformationalTagHelper.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace RazorToolingTestApp.Library
+{
+    public class InformationalTagHelper : TagHelper
+    {
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.TagName = null;
+            output.Content.SetContent($"This is information from the {typeof(InformationalTagHelper).FullName}.");
+        }
+    }
+}

--- a/testapps/RazorToolingTestApp.Library/RazorToolingTestApp.Library.xproj
+++ b/testapps/RazorToolingTestApp.Library/RazorToolingTestApp.Library.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>cf8d2020-2f4c-4c9f-9b5e-76a0a3e33731</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/testapps/RazorToolingTestApp.Library/project.json
+++ b/testapps/RazorToolingTestApp.Library/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "version": "1.0.0",
+
+  "dependencies": {
+    "Microsoft.AspNetCore.Razor.Runtime": "1.1.0-*"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0-*"
+      }
+    },
+    "net451": {}
+  }
+}

--- a/testapps/RazorToolingTestApp/Controllers/HomeController.cs
+++ b/testapps/RazorToolingTestApp/Controllers/HomeController.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace RazorToolingTestApp.Controllers
+{
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/testapps/RazorToolingTestApp/Program.cs
+++ b/testapps/RazorToolingTestApp/Program.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+
+namespace RazorToolingTestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/testapps/RazorToolingTestApp/RazorToolingTestApp.xproj
+++ b/testapps/RazorToolingTestApp/RazorToolingTestApp.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2f254ff7-6b16-4c1c-8683-0d21c887611e</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/testapps/RazorToolingTestApp/Startup.cs
+++ b/testapps/RazorToolingTestApp/Startup.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace RazorToolingTestApp
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole();
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMvcWithDefaultRoute();
+        }
+    }
+}

--- a/testapps/RazorToolingTestApp/Views/Home/Index.cshtml
+++ b/testapps/RazorToolingTestApp/Views/Home/Index.cshtml
@@ -1,0 +1,6 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+<p enum-property="FirstValue">Hello world</p>
+<informational />

--- a/testapps/RazorToolingTestApp/Views/Shared/_Layout.cshtml
+++ b/testapps/RazorToolingTestApp/Views/Shared/_Layout.cshtml
@@ -1,0 +1,13 @@
+﻿<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>@ViewBag.Title</title>
+</head>
+<body>
+    <div>
+        @RenderBody()
+    </div>
+</body>
+</html>

--- a/testapps/RazorToolingTestApp/Views/_ViewImports.cshtml
+++ b/testapps/RazorToolingTestApp/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, RazorToolingTestApp.Library
+@addTagHelper *, RazorToolingTestApp.LibraryPackage

--- a/testapps/RazorToolingTestApp/Views/_ViewStart.cshtml
+++ b/testapps/RazorToolingTestApp/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/testapps/RazorToolingTestApp/project.json
+++ b/testapps/RazorToolingTestApp/project.json
@@ -1,0 +1,50 @@
+﻿{
+  "dependencies": {
+    "Microsoft.AspNetCore.Diagnostics": "1.1.0-*",
+    "Microsoft.AspNetCore.Mvc": "1.1.0-*",
+    "Microsoft.AspNetCore.Razor.Design": {
+      "type": "build",
+      "version": "1.0.0-*",
+      "target": "package"
+    },
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.1.0-*",
+    "RazorToolingTestApp.Library": "1.0.0",
+    "RazorToolingTestApp.LibraryPackage": {
+      "version": "1.0.0",
+      "target": "package" /* Remove this line and the above comma to have this project restore outside of tests */
+    }
+  },
+
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-*",
+    "Microsoft.AspNetCore.Razor.Tools": "1.0.0-*"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        }
+      }
+    },
+    "net451": {}
+  },
+
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "warningsAsErrors": true,
+    "preserveCompilationContext": true
+  },
+
+  "publishOptions": {
+    "include": [
+      "Views",
+      "wwwroot",
+      "web.config"
+    ]
+  }
+}

--- a/testapps/RazorToolingTestApp/web.config
+++ b/testapps/RazorToolingTestApp/web.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!--
+    Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
+  -->
+
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+  </system.webServer>
+</configuration>

--- a/testartifacts/.gitignore
+++ b/testartifacts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!initialpackages


### PR DESCRIPTION
- This involved building a simple test application to perform dotnet commands onto.
- Created a testartifacts directory during functional test runs to isolate functional test package requirements from a users machine. Without this you'd end up with temporary packages polluting your local nuget packages home directory.
- Wrote a few e2e tests to cover the majority of functional scenarios.

#62 

/cc @pranavkm @natemcmaster 